### PR TITLE
run websocket-server/server.php in app container

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -53,9 +53,10 @@ dockerのインストーラは以下のページよりダウンロードでき�
 - [Windows 10 64bit Pro](https://www.docker.com/docker-windows)
 - [Mac OSX Yosemite 10.10.3以上](https://www.docker.com/docker-mac)
 
-### アプリとデータベース
+### アプリ(app)とデータベース(db)
 
 アプリのWebサーバにはApache、データベースにはMySQLを使用しています。
+アプリにはWebサーバの他に、WebSocketがphpで8000番ポートで起動します。
 
 データベースのコンテナはDockerfileからbuildするのではなく、[mysql](https://hub.docker.com/r/_/mysql/)のイメージに設定と初期データのあるディレクトリをデータ・ボリュームとしてマウントさせています。
 
@@ -69,6 +70,9 @@ Happy2システムのdockerコンテナでは、まだ確認できない機能�
 - ログイン後のホーム画面でリロードすると、値が初期化され、前の状態を表示できない。
 - 集計機能がない。
 - 履歴が更新されなくなることがある。
-- 通知機能が使えない。Web Socketによる通信ができない。
 
+## 更新履歴
+
+### 2017-11-29
+-  appコンテナでWebSocketを起動。通知機能がONに。
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -24,7 +24,7 @@ RUN echo include_path=".:/usr/PEAR" >> /etc/php.ini && \
     echo 'mbstring.detect_order =  UTF-8,EUC-JP,SJIS,JIS,ASCII' >> /etc/php.ini && \
     echo 'mbstring.substitute_character = none;' >> /etc/php.ini
 
-RUN yum install -y telnet mysql
+RUN yum install -y telnet mysql sudo bind-utils net-tools
 
 RUN cd /var/www && git clone --depth 1 https://github.com/sakamata/happy2.git
 
@@ -33,6 +33,11 @@ RUN mkdir -p /var/www/hidden  /var/hidden/ && \
 
 COPY info.php /var/hidden/
 COPY virtual.conf /etc/httpd/conf.d/
+COPY docker-entrypoint.sh /
 
-CMD httpd -DFOREGROUND
+# CMD httpd -DFOREGROUND
+
+EXPOSE 80 443 8000
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
 

--- a/docker/app/docker-entrypoint.sh
+++ b/docker/app/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+set -e
+
+if [ "$1" = "" ]; then
+  php /var/www/happy2/websocket-server/server.php &
+  exec httpd -DFOREGROUND
+fi
+
+exec "$@"
+

--- a/docker/app/info.php
+++ b/docker/app/info.php
@@ -1,6 +1,7 @@
 <?php
-$hostName = 'localhost';
-$permitDomain ='localhost';
+$hostName = '0.0.0.0';
+$permitDomain ='127.0.0.1';
+$checkOrigin = false;
 
 //$hostName = '160.16.221.26';
 //$permitDomain ='160.16.221.26';
@@ -25,6 +26,4 @@ if (filter_input(INPUT_SERVER, 'HTTPS', FILTER_VALIDATE_BOOLEAN)) {
         $wsSSL = false;
         $wsProtocol = 'ws';
 }
-
-?>
 

--- a/docker/app/virtual.conf
+++ b/docker/app/virtual.conf
@@ -2,10 +2,10 @@
 # 開発/本番 # development or product
 SetEnv SERVER_ENV       development
 # WebSocket // ドメインを指定 開発環境では'127.0.0.1'
-SetEnv HOST_NAME        'localhost'
-SetEnv PERMIT_DOMAIN	localhost
+SetEnv HOST_NAME        '0.0.0.0'
+SetEnv PERMIT_DOMAIN	'127.0.0.1'
 #  //websocket通信に使用するPort番号を指定
-SetEnv WS_PORT          80
+SetEnv WS_PORT          8000
 # MySQL
 # ; //databaseのpasswordを指定
 SetEnv SQL_PASS			'mysql'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,16 +3,19 @@ services:
   app:
     container_name: happy2-app
     build: app
+    hostname: happy2
     ports:
       - "80:80"
       - "443:443"
-    links:
-      - db
+      - "127.0.0.1:8000:8000"
+    external_links:
+      - happy2-db:db
     depends_on:
       - db
   db:
     container_name: happy2-db
     # build: db
+    hostname: db
     image: mysql
     ports:
       - "3306:3306"

--- a/websocket-server/server.php
+++ b/websocket-server/server.php
@@ -23,7 +23,7 @@ $server = new \WebSocket\Server($hostName, $wsPort, $wsSSL);
 
 // server settings:
 $server->setMaxClients(200);
-$server->setCheckOrigin(true);
+$server->setCheckOrigin(isset($checkOrigin) ? $checkOrigin : true);
 
 // 通信を許可するドメイン 複数指定可能
 $server->setAllowedOrigin($permitDomain);


### PR DESCRIPTION
WebSocketのsetCheckOriginにfalseがセットできるようにしました。(info.php : $checkOrigin変数)
これにより、dockerホストの固有ホスト名をコンテナ内に設定せず、WebSocketを起動することができました。